### PR TITLE
Change gem name to fluent-plugin-splunk-enterprise

### DIFF
--- a/README.hec.md
+++ b/README.hec.md
@@ -1,7 +1,5 @@
 # out_splunk_hec - Splunk HTTP Event Collector Output Plugin
 
-**This plugin is only for Fluentd Enterprise.**
-
 ## Table of Contents
 
 * [Example Configuration](#example-configuration)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
-[![CircleCI](https://circleci.com/gh/treasure-data/fluent-plugin-splunk.svg?style=svg&circle-token=1303d4617f67c8d2e277f181dffd0a62d59dffea)](https://circleci.com/gh/treasure-data/fluent-plugin-splunk)
-
-# Fluent::Plugin::Splunk
-
-**This plugin is only for Fluentd Enterprise.**
+# fluent-plugin-splunk-enterprise
 
 ## Table of Contents
 
+* [Installation](#installation)
 * [out_splunk_hec](#out_splunk_hec)
 * [out_splunk_tcp](#out_splunk_tcp)
 * [Running test](#running-tests)
+
+## Installation
+
+```
+$ fluent-gem install fluent-plugin-splunk-enterprise
+```
 
 ## [out_splunk_hec](/README.hec.md)
 

--- a/README.tcp.md
+++ b/README.tcp.md
@@ -1,7 +1,5 @@
 # out_splunk_tcp - Splunk TCP inputs Output Plugin
 
-**This plugin is only for Fluentd Enterprise.**
-
 ## Table of Contents
 
 * [Example Configuration](#example-configuration)

--- a/fluent-plugin-splunk-enterprise.gemspec
+++ b/fluent-plugin-splunk-enterprise.gemspec
@@ -3,7 +3,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name          = "fluent-plugin-splunk"
+  spec.name          = "fluent-plugin-splunk-enterprise"
   spec.version       = "1.0.0"
   spec.authors       = ["Yuki Ito", "Masahiro Nakagawa"]
   spec.email         = ["yito@treasure-data.com", "repeatedly@gmail.com"]


### PR DESCRIPTION
We are now contacting fluent-plugin-splunk author, but
no good response for now.
So use fluent-plugin-splunk-enterprise name temporarily.

https://github.com/parolkar/fluent-plugin-splunk/issues/2

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>