### PR TITLE
Added support for removing the keys used to set source, index and host

### DIFF
--- a/README.hec.md
+++ b/README.hec.md
@@ -82,13 +82,21 @@ If you set this, the value is set as host metadata.
 
 If you set this, the value associated with this key in each record is used as host metadata. When the key is missing, `default_host` is used.
 
-### defaout_source
+### remove_host_key
+
+If you set this, the field specified by the `host_key` will be removed
+
+### default_source
 
 If you set this, the value is set as source metadata.
 
 ### source_key
 
 If you set this, the value associated with this key in each record is used as source metadata. When the key is missing, `default_source` is used.
+
+### remove_source_key
+
+If you set this, the field specified by the `source_key` will be removed
 
 ### default_index
 
@@ -97,6 +105,10 @@ If you set this, the value is set as index metadata.
 ### index_key
 
 If you set this, the value associated with this key in each record is used as index metadata. When the key is missing, `default_index` is used.
+
+### remove_index_key
+
+If you set this, the field specified by the `index_key` will be removed
 
 ### sourcetype
 

--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -109,6 +109,7 @@ module Fluent
         msg['host'] = record[@host_key]
         if @remove_host_key
             record.delete(@host_key)
+        end
       elsif @default_host
         msg['host'] = @default_host
       end
@@ -117,6 +118,7 @@ module Fluent
         msg['source'] = record[@source_key]
         if @remove_source_key
             record.delete(@source_key)
+        end
       elsif @default_source
         msg['source'] = @default_source
       end
@@ -125,6 +127,7 @@ module Fluent
         msg['index'] = record[@index_key]
         if @remove_index_key
             record.delete(@index_key)
+        end
       elsif @default_index
         msg['index'] = @default_index
       end

--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -15,10 +15,13 @@ module Fluent
     # for metadata
     config_param :default_host, :string, default: nil
     config_param :host_key, :string, default: nil
+    config_param :remove_host_key, :string, default: false
     config_param :default_source, :string, default: nil
     config_param :source_key, :string, default: nil
+    config_param :remove_source_key, :bool, default: false
     config_param :default_index, :string, default: nil
     config_param :index_key, :string, default: nil
+    config_param :remove_index_key, :bool, default: false
     config_param :sourcetype, :string, default: nil
     config_param :use_fluentd_time, :bool, default: true
 
@@ -104,18 +107,24 @@ module Fluent
 
       if record[@host_key]
         msg['host'] = record[@host_key]
+        if @remove_host_key
+            record.delete(@host_key)
       elsif @default_host
         msg['host'] = @default_host
       end
 
       if record[@source_key]
         msg['source'] = record[@source_key]
+        if @remove_source_key
+            record.delete(@source_key)
       elsif @default_source
         msg['source'] = @default_source
       end
 
       if record[@index_key]
         msg['index'] = record[@index_key]
+        if @remove_index_key
+            record.delete(@index_key)
       elsif @default_index
         msg['index'] = @default_index
       end


### PR DESCRIPTION
Pull request to add configuration option to remove the fields that can be used for specifying "host", "source" and "index".

These fields can be constructed dynamically and can lead to duplication of data elements as well as "litter" in the log record in splunk.