### PR TITLE
Added support for having sourcetype as key in record (like host, index etc)

### DIFF
--- a/README.hec.md
+++ b/README.hec.md
@@ -14,7 +14,10 @@
    * [source_key](#source_key)
    * [default_index](#default_index)
    * [index_key](#index_key)
+   * [default_sourcetype](#default_sourcetype)
    * [sourcetype](#sourcetype)
+   * [sourcetype_key](#sourcetype_key)
+   * [remove_sourcetype_key](#remove_sourcetype_key)
    * [use_fluentd_time](#use_fluentd_time)
    * [use_ack](#use_ack)
    * [channel](#channel)
@@ -110,9 +113,21 @@ If you set this, the value associated with this key in each record is used as in
 
 If you set this, the field specified by the `index_key` will be removed
 
+### default_sourcetype
+
+If you set this, the value is set as sourcetype metadata if `sourcetype_key` is not set or not found in the record.
+
 ### sourcetype
 
-If you set this, the value is set as sourcetype metadata.
+Deprecated. Same as `default_sourcetype`, kept for backwards compability.
+
+### sourcetype_key
+
+If you set this, the value associated with this key in each record is used as sourcetype metadata. When the key is missing, `default_sourcetype` is used.
+
+### remove_sourcetype_key
+
+If you set this, the field specified by the `sourcetype_key` will be removed
 
 ### use_fluentd_time
 

--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -22,7 +22,7 @@ module Fluent
     config_param :default_index, :string, default: nil
     config_param :index_key, :string, default: nil
     config_param :remove_index_key, :bool, default: false
-    config_param :sourcetype, :string, default: nil
+    config_param :sourcetype, :string, default: nil, deprecated: "Use default_sourcetype instead"
     config_param :default_sourcetype, :string, default: nil
     config_param :sourcetype_key, :string, default: nil
     config_param :remove_sourcetype_key, :bool, default: false

--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -23,6 +23,9 @@ module Fluent
     config_param :index_key, :string, default: nil
     config_param :remove_index_key, :bool, default: false
     config_param :sourcetype, :string, default: nil
+    config_param :default_sourcetype, :string, default: nil
+    config_param :sourcetype_key, :string, default: nil
+    config_param :remove_sourcetype_key, :bool, default: false
     config_param :use_fluentd_time, :bool, default: true    
 
     # for Indexer acknowledgement
@@ -52,6 +55,8 @@ module Fluent
       raise ConfigError, "'ack_interval' parameter must be a non negative integer" if @use_ack && @ack_interval < 0
       raise ConfigError, "'event_key' parameter is required when 'raw' is true" if @raw && !@event_key
       raise ConfigError, "'channel' parameter is required when 'raw' is true" if @raw && !@channel
+      
+      @default_sourcetype = @sourcetype if @sourcetype && !@default_sourcetype
 
       # build hash for query string
       if @raw
@@ -59,7 +64,7 @@ module Fluent
         @query['host'] = @default_host if @default_host
         @query['source'] = @default_source if @default_source
         @query['index'] = @default_index if @default_index
-        @query['sourcetype'] = @sourcetype if @sourcetype
+        @query['sourcetype'] = @default_sourcetype if @default_sourcetype
       end
     end
 
@@ -103,7 +108,11 @@ module Fluent
       msg['time'] = time if @use_fluentd_time
 
       # metadata
-      msg['sourcetype'] = @sourcetype if @sourcetype
+      if record[@sourcetype_key]
+        msg['sourcetype'] = @remove_sourcetype_key ? record.delete(@sourcetype_key) : record[@sourcetype_key]
+      elsif @default_sourcetype
+        msg['sourcetype'] = @default_sourcetype
+      end
 
       if record[@host_key]
         msg['host'] = @remove_host_key ? record.delete(@host_key) : record[@host_key]


### PR DESCRIPTION
Left `sourcetype` for backwards compability, it will double with `default_sourcetype`. 
Manually tested in production like environment as well.