### PR TITLE
Send time with nano seconds if possible when use_fluentd_time is set to true

### DIFF
--- a/README.hec.md
+++ b/README.hec.md
@@ -19,6 +19,7 @@
    * [sourcetype_key](#sourcetype_key)
    * [remove_sourcetype_key](#remove_sourcetype_key)
    * [use_fluentd_time](#use_fluentd_time)
+   * [time_as_integer](#time_as_integer) 
    * [use_ack](#use_ack)
    * [channel](#channel)
    * [ack_interval](#ack_interval)
@@ -134,6 +135,12 @@ If you set this, the field specified by the `sourcetype_key` will be removed
 The default: `true`
 
 If set true, fluentd's timestamp is used as time metadata. If the record already has its own time value, this options should be `false`.
+
+### time_as_integer
+
+The default: `true`
+
+Only used when `use_fluentd_time` is `true`. If set to `true` (default), time will be sent as integer seconds to Splunk, whereas if set to `false`, it will be sent with nano seconds.
 
 ### use_ack
 

--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -105,7 +105,9 @@ module Fluent
 
     def format_event(time, record)
       msg = {'event' => record}
-      msg['time'] = time if @use_fluentd_time
+      if @use_fluentd_time
+        msg['time'] = time.respond_to?('to_f') ? time.to_f : time
+      end
 
       # metadata
       if record[@sourcetype_key]

--- a/test/test_out_splunk_hec.rb
+++ b/test/test_out_splunk_hec.rb
@@ -445,6 +445,21 @@ class SplunkHECOutputTest < Test::Unit::TestCase
           assert_equal('sourcetype_test', result['result']['_sourcetype'])
           assert_equal(event, JSON.parse(result['result']['_raw']))
         end
+
+        test '_time is sent with nano seconds when use_fluentd_time is true and time_as_integer is false' do
+          config = merge_config(test_config[:default_config_no_ack], %[
+            use_fluentd_time true
+            time_as_integer false
+          ])
+          d = create_driver(config)
+          event = {'test' => SecureRandom.hex}
+          time = Fluent::EventTime.new(1560349063, 576000000)
+          d.emit(event, time)
+          d.run
+          result = get_events(test_config[:query_port], "source=\"#{DEFAULT_SOURCE_FOR_NO_ACK}\"")[0]
+          assert_equal(1560349063.576, result['result']['_time'].to_f)
+          assert_equal(event, JSON.parse(result['result']['_raw']))
+        end
       end
 
       if SPLUNK_VERSION >= to_version('6.4.0')


### PR DESCRIPTION
Parent class has a config parameter `time_as_integer` defaulted to `true` for 0.12 compability reasons. If setting this to `false`, the time sent to `format_event` (called from from `def write_objects(_tag, chunk)`) will be a `Fluentd::EventTime` object with nanos instead of an Integer. If possible, send the nano time to splunk.

Tested in live environment and it works fine. Added Unit test but I have not been able to run the tests since I couldn't get the test environment with Splunk in Docker etc to work (documentation refers to a `docker.sh` file that has been removed.. :) ). But it _should_ work...

I would be possible to default the `time_as_integer` to false, but then it would break for 0.12 users unless they configure it to true.