### PR TITLE
Revive docker.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Available Splunk versions in tests are `6.5.2`, `6.4.6`, `6.3.9`, `6,2.12`, `6.1
 Start a docker instance Splunk.
 
 ```
-$ ./docker.sh login
-$ ./docker.sh debug_run <splunk_version>
+$ ./docker.sh build <splunk_version>
+$ ./docker.sh run <splunk_version>
 ```
 
 Run tests.

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+COMMAND=$1
+VERSION=$2
+IMAGE_LOCAL=splunk-for-test:${VERSION}
+
+PORTS="-p 8000:8000 -p 8089:8089 -p 8191:8191 -p 12300:12300 -p 12301:12301 -p 12302:12302 -p 12303:12303 -p 12304:12304 -p 12305:12305 -p 1514:1514 -p 8088:8088 \
+       -p 8200:8200 -p 8289:8289 -p 8391:8391 -p 12500:12500 -p 12501:12501 -p 12502:12502 -p 12503:12503 -p 12504:12504 -p 12505:12505 -p 1714:1714 -p 8288:8288"
+
+VOLUME="-v ${PWD}/test/config/props.conf:/opt/splunk_tcp/etc/system/local/props.conf \
+        -v ${PWD}/test/config/props.conf:/opt/splunk_ssl/etc/system/local/props.conf \
+        -v ${PWD}/test/config/inputs.tcp.conf:/opt/splunk_tcp/etc/apps/search/local/inputs.conf \
+        -v ${PWD}/test/config/inputs.ssl.conf:/opt/splunk_ssl/etc/apps/search/local/inputs.conf"
+
+if [ "$VERSION" = "6.3.9" ]; then
+  VOLUME="${VOLUME} \
+          -v ${PWD}/test/config/server.conf.6.3:/opt/splunk_ssl/etc/system/local/server.conf.original \
+          -v ${PWD}/test/config/entrypoint.sh.6.3:/sbin/entrypoint.sh"
+
+fi
+
+case "$COMMAND" in
+  run)
+    docker run -d --entrypoint=/bin/bash ${PORTS} ${VOLUME} ${IMAGE_LOCAL} /sbin/entrypoint.sh
+    ;;
+  stop)
+    docker stop $(docker ps -q --filter ancestor=${IMAGE_LOCAL})
+    ;;
+  build)
+    docker build -t ${IMAGE_LOCAL} test/Dockerfiles/enterprise/${VERSION}
+    ;;
+  force_build)
+    docker build --no-cache=true -t ${IMAGE_LOCAL} test/Dockerfiles/enterprise/${VERSION}
+    ;;
+  *)
+    echo "Unkowon command"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
I revived the file which was deleted in https://github.com/fluent/fluent-plugin-splunk/commit/07ad63f555bf1c77594334d36aa3fb554683079c and update README to catch up a present environment.
For now, I skipped to revived the CI file since it needs to build docker images and building them takes too much time.

I hope this change will help with https://github.com/fluent/fluent-plugin-splunk/pull/20

@repeatedly Can you review this?
