### PR TITLE
Discard empty events

### DIFF
--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -153,7 +153,12 @@ module Fluent
     end
 
     def format_event_raw(record)
-      (record[@event_key] || '') + @line_breaker
+      if record[@event_key] and not record[@event_key].strip.empty?
+        record[@event_key] + @line_breaker
+      else
+        log.debug "Discarding empty line"
+        ''
+      end
     end
 
     def post(path, body, query = {})

--- a/test/test_out_splunk_hec.rb
+++ b/test/test_out_splunk_hec.rb
@@ -558,6 +558,25 @@ class SplunkHECOutputTest < Test::Unit::TestCase
             result = get_events(test_config[:query_port], "source=\"#{DEFAULT_SOURCE_FOR_NO_ACK}\"")[0]
             assert_equal(event, JSON.parse(result['result']['_raw']))
           end
+
+          test 'with empty statement' do
+              config = merge_config(test_config[:default_config_no_ack], %[
+                raw true
+                channel #{[SecureRandom.hex(4), SecureRandom.hex(2), SecureRandom.hex(2), SecureRandom.hex(2), SecureRandom.hex(6)].join('-')}
+                event_key splunk_event
+              ])
+
+              d = create_driver(config)
+              time = Time.now.to_i - 100
+              event = "raw event"
+              record1 = {'splunk_event' => " "}
+              record2 = {'splunk_event' => event}
+              d.emit(record1, time)
+              d.emit(record2, time)
+              d.run
+              result = get_events(test_config[:query_port], "source=\"#{DEFAULT_SOURCE_FOR_NO_ACK}\"")[0]
+              assert_equal(event, result['result']['_raw'])
+            end
         end
       end
     end


### PR DESCRIPTION
Splunk hec will discard empty events and give an error. Events that only contain for example a newline character '\n' will give an error. This can crash the plugin if it is set up to retry too often.