### PR TITLE
enable 'event_key' for non-raw setup.

### DIFF
--- a/README.hec.md
+++ b/README.hec.md
@@ -184,10 +184,12 @@ Example:
 
 ### event_key
 
-Only for raw mode. The value specified by this key is sent as an event.
+The value specified by this key is sent as an event.
+All other keys are discarded.
 When `raw` is set to `true`, this parameter is required.
 
 * fluentd record: `1490924392 {"log": "GET / HTTP/1.1 200"}`
+* event_key "log"
 * sent as: `GET / HTTP/1.1 200`
 
 ### line_breaker

--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -117,7 +117,12 @@ module Fluent
     end
 
     def format_event(time, record)
-      msg = {'event' => record}
+      if @event_key
+        msg = {'event' => (record[@event_key] || '')}
+      else
+        msg = {'event' => record}
+      end
+
       if @use_fluentd_time
         msg['time'] = time.respond_to?('to_f') ? time.to_f : time
       end

--- a/test/test_out_splunk_hec.rb
+++ b/test/test_out_splunk_hec.rb
@@ -430,6 +430,20 @@ class SplunkHECOutputTest < Test::Unit::TestCase
           assert_equal(event, JSON.parse(result['result']['_raw']))
         end
 
+        test 'non raw with event_key' do
+          config = merge_config(test_config[:default_config_no_ack], %[
+            event_key log
+          ])
+          d = create_driver(config)
+          event = {'log' => SecureRandom.hex}
+          time = Time.now.to_i - 100
+          d.emit(event, time)
+          d.run
+          result = get_events(test_config[:query_port], "source=\"#{DEFAULT_SOURCE_FOR_NO_ACK}\"")[0]
+          assert_equal(time, result['result']['_time'].to_i)
+          assert_equal(event['log'], result['result']['_raw'])
+        end
+
         # Backward compability (sourcetype) test
         test 'source_type = sourcetype_test' do
           config = merge_config(test_config[:default_config_no_ack], %[


### PR DESCRIPTION
event_key is currently only supported when in 'raw' mode.
It will be beneficial to also have this option in the other mode - usually the event is a json object, and this enables the plugin to send just the log string as the event.
When compared to using just 'raw' mode - this method adds various benefits - such as being able to use 'use_fluentd_time'
