### PR TITLE
Prevent token appearing in log output

### DIFF
--- a/lib/fluent/plugin/out_splunk_hec.rb
+++ b/lib/fluent/plugin/out_splunk_hec.rb
@@ -11,7 +11,7 @@ module Fluent
 
     config_param :host, :string
     config_param :port, :integer
-    config_param :token, :string
+    config_param :token, :string, secret: true
 
     # for metadata
     config_param :default_host, :string, default: nil


### PR DESCRIPTION
Mark token as a secret parameter to prevent it appearing in log output.

Fixes #34 

Probably needs tests before merging, but I'm not sure how to test visibility of the token in log output.